### PR TITLE
Feat: Add switchable SMS registration confirmation

### DIFF
--- a/src/server/API/appsettings.json
+++ b/src/server/API/appsettings.json
@@ -22,7 +22,14 @@
     "Port": 587,
     "UserName": "adaline.pfannerstill49@ethereal.email",
     "Password": "vAKmWQB8CyPUBg8rBQ",
-    "DisplayName": "Mukesh Murugan"
+    "DisplayName": "Mukesh Murugan",
+    "EnableVerification": true
+  },
+  "SmsSettings": {
+    "SmsAccountIdentification": "$ecRet!AccountSID",
+    "SmsAccountPassword": "Pa$$word!OrAuthToken",
+    "SmsAccountFrom": "+11111111111",
+    "EnableVerification": false
   },
   "PersistenceSettings": {
     "UseMsSql": false,

--- a/src/server/Modules/Identity/Modules.Identity.Core/Abstractions/IIdentityService.cs
+++ b/src/server/Modules/Identity/Modules.Identity.Core/Abstractions/IIdentityService.cs
@@ -10,7 +10,7 @@ namespace FluentPOS.Modules.Identity.Core.Abstractions
 
         Task<IResult<string>> ConfirmEmailAsync(string userId, string code);
 
-        Task<IResult<string>> ConfirmSmsAsync(string userId, string code);
+        Task<IResult<string>> ConfirmPhoneNumberAsync(string userId, string code);
 
         Task<IResult> ForgotPasswordAsync(ForgotPasswordRequest request, string origin);
 

--- a/src/server/Modules/Identity/Modules.Identity.Core/Abstractions/IIdentityService.cs
+++ b/src/server/Modules/Identity/Modules.Identity.Core/Abstractions/IIdentityService.cs
@@ -10,6 +10,8 @@ namespace FluentPOS.Modules.Identity.Core.Abstractions
 
         Task<IResult<string>> ConfirmEmailAsync(string userId, string code);
 
+        Task<IResult<string>> ConfirmSmsAsync(string userId, string code);
+
         Task<IResult> ForgotPasswordAsync(ForgotPasswordRequest request, string origin);
 
         Task<IResult> ResetPasswordAsync(ResetPasswordRequest request);

--- a/src/server/Modules/Identity/Modules.Identity.Infrastructure/Services/IdentityService.cs
+++ b/src/server/Modules/Identity/Modules.Identity.Infrastructure/Services/IdentityService.cs
@@ -179,7 +179,7 @@ namespace FluentPOS.Modules.Identity.Infrastructure.Services
             }
         }
 
-        public async Task<IResult<string>> ConfirmSmsAsync(string userId, string code)
+        public async Task<IResult<string>> ConfirmPhoneNumberAsync(string userId, string code)
         {
             var user = await _userManager.FindByIdAsync(userId);
             if (user == null)

--- a/src/server/Modules/Identity/Modules.Identity.Infrastructure/Services/IdentityService.cs
+++ b/src/server/Modules/Identity/Modules.Identity.Infrastructure/Services/IdentityService.cs
@@ -10,11 +10,15 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.EntityFrameworkCore;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
+using FluentPOS.Shared.Core.Settings;
+using FluentPOS.Shared.DTOs.Sms;
 using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Options;
 
 namespace FluentPOS.Modules.Identity.Infrastructure.Services
 {
@@ -23,17 +27,26 @@ namespace FluentPOS.Modules.Identity.Infrastructure.Services
         private readonly UserManager<FluentUser> _userManager;
         private readonly IJobService _jobService;
         private readonly IMailService _mailService;
+        private readonly MailSettings _mailSettings;
+        private readonly SmsSettings _smsSettings;
+        private readonly ISmsService _smsService;
         private readonly IStringLocalizer<IdentityService> _localizer;
 
         public IdentityService(
             UserManager<FluentUser> userManager,
             IJobService jobService,
             IMailService mailService,
+            IOptions<MailSettings> mailSettings,
+            IOptions<SmsSettings> smsSettings,
+            ISmsService smsService,
             IStringLocalizer<IdentityService> localizer)
         {
             _userManager = userManager;
             _jobService = jobService;
             _mailService = mailService;
+            _mailSettings = mailSettings.Value;
+            _smsSettings = smsSettings.Value;
+            _smsService = smsService;
             _localizer = localizer;
         }
 
@@ -75,16 +88,43 @@ namespace FluentPOS.Modules.Identity.Infrastructure.Services
                     {
                     }
 
-                    var verificationUri = await SendVerificationEmail(user, origin);
-                    var mailRequest = new MailRequest
+                    if (!_mailSettings.EnableVerification && !_smsSettings.EnableVerification)
                     {
-                        From = "mail@codewithmukesh.com",
-                        To = user.Email,
-                        Body = string.Format(_localizer["Please confirm your account by <a href='{0}'>clicking here</a>."], verificationUri),
-                        Subject = _localizer["Confirm Registration"]
-                    };
-                    _jobService.Enqueue(() => _mailService.SendAsync(mailRequest));
-                    return await Result<string>.SuccessAsync(user.Id, message: string.Format(_localizer["User {0} Registered. Please check your Mailbox to verify!"], user.UserName));
+                        return await Result<string>.SuccessAsync(user.Id, message: string.Format(_localizer["User {0} Registered."], user.UserName));
+                    }
+
+                    var messages = new List<string> {string.Format(_localizer["User {0} Registered."], user.UserName)};
+                    if (_mailSettings.EnableVerification)
+                    {
+                        // send verification email
+                        var emailVerificationUri = await GetEmailVerificationUri(user, origin);
+                        var mailRequest = new MailRequest
+                        {
+                            From = "mail@codewithmukesh.com",
+                            To = user.Email,
+                            Body = string.Format(_localizer["Please confirm your FluentPOS account by <a href='{0}'>clicking here</a>."], emailVerificationUri),
+                            Subject = _localizer["Confirm Registration"]
+                        };
+                        _jobService.Enqueue(() => _mailService.SendAsync(mailRequest));
+
+                        messages.Add(_localizer["Please check your Mailbox to verify!"]);
+                    }
+
+                    if (_smsSettings.EnableVerification)
+                    {
+                        // send verification sms
+                        var mobilePhoneVerificationCode = await GetMobilePhoneVerificationCode(user);
+                        var smsRequest = new SmsRequest
+                        {
+                            Number = user.PhoneNumber,
+                            Message = string.Format(_localizer["Please confirm your FluentPOS account by this code: {0}"], mobilePhoneVerificationCode)
+                        };
+                        _jobService.Enqueue(() => _smsService.SendAsync(smsRequest));
+
+                        messages.Add(_localizer["Please check your Phone for code in SMS to verify!"]);
+                    }
+
+                    return await Result<string>.SuccessAsync(user.Id, messages: messages);
                 }
                 else
                 {
@@ -97,7 +137,7 @@ namespace FluentPOS.Modules.Identity.Infrastructure.Services
             }
         }
 
-        private async Task<string> SendVerificationEmail(FluentUser user, string origin)
+        private async Task<string> GetEmailVerificationUri(FluentUser user, string origin)
         {
             var code = await _userManager.GenerateEmailConfirmationTokenAsync(user);
             code = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(code));
@@ -108,18 +148,59 @@ namespace FluentPOS.Modules.Identity.Infrastructure.Services
             return verificationUri;
         }
 
+        private async Task<string> GetMobilePhoneVerificationCode(FluentUser user)
+        {
+            return await _userManager.GenerateChangePhoneNumberTokenAsync(user, user.PhoneNumber);
+        }
+
         public async Task<IResult<string>> ConfirmEmailAsync(string userId, string code)
         {
             var user = await _userManager.FindByIdAsync(userId);
+            if (user == null)
+            {
+                throw new IdentityException(_localizer["An error occurred while confirming E-Mail."]);
+            }
             code = Encoding.UTF8.GetString(WebEncoders.Base64UrlDecode(code));
             var result = await _userManager.ConfirmEmailAsync(user, code);
             if (result.Succeeded)
             {
-                return await Result<string>.SuccessAsync(user.Id, string.Format(_localizer["Account Confirmed for {0}. You can now use the /api/identity/token endpoint to generate JWT."], user.Email));
+                if (user.PhoneNumberConfirmed)
+                {
+                    return await Result<string>.SuccessAsync(user.Id, string.Format(_localizer["Account Confirmed for E-Mail {0}. You can now use the /api/identity/token endpoint to generate JWT."], user.Email));
+                }
+                else
+                {
+                    return await Result<string>.SuccessAsync(user.Id, string.Format(_localizer["Account Confirmed for E-Mail {0}. You should confirm your Phone Number before using the /api/identity/token endpoint to generate JWT."], user.Email));
+                }
             }
             else
             {
                 throw new IdentityException(string.Format(_localizer["An error occurred while confirming {0}"], user.Email));
+            }
+        }
+
+        public async Task<IResult<string>> ConfirmSmsAsync(string userId, string code)
+        {
+            var user = await _userManager.FindByIdAsync(userId);
+            if (user == null)
+            {
+                throw new IdentityException(_localizer["An error occurred while confirming Mobile Phone."]);
+            }
+            var result = await _userManager.ChangePhoneNumberAsync(user, user.PhoneNumber, code);
+            if (result.Succeeded)
+            {
+                if (user.EmailConfirmed)
+                {
+                    return await Result<string>.SuccessAsync(user.Id, string.Format(_localizer["Account Confirmed for Phone Number {0}. You can now use the /api/identity/token endpoint to generate JWT."], user.PhoneNumber));
+                }
+                else
+                {
+                    return await Result<string>.SuccessAsync(user.Id, string.Format(_localizer["Account Confirmed for Phone Number {0}. You should confirm your E-mail before using the /api/identity/token endpoint to generate JWT."], user.PhoneNumber));
+                }
+            }
+            else
+            {
+                throw new IdentityException(string.Format(_localizer["An error occurred while confirming {0}"], user.PhoneNumber));
             }
         }
 
@@ -137,10 +218,10 @@ namespace FluentPOS.Modules.Identity.Infrastructure.Services
             code = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(code));
             var route = "account/reset-password";
             var endpointUri = new Uri(string.Concat($"{origin}/", route));
-            var passwordResetURL = QueryHelpers.AddQueryString(endpointUri.ToString(), "Token", code);
+            var passwordResetUrl = QueryHelpers.AddQueryString(endpointUri.ToString(), "Token", code);
             var mailRequest = new MailRequest
             {
-                Body = string.Format(_localizer["Please reset your password by <a href='{0}>clicking here</a>."], HtmlEncoder.Default.Encode(passwordResetURL)),
+                Body = string.Format(_localizer["Please reset your password by <a href='{0}>clicking here</a>."], HtmlEncoder.Default.Encode(passwordResetUrl)),
                 Subject = _localizer["Reset Password"],
                 To = request.Email
             };

--- a/src/server/Modules/Identity/Modules.Identity/Controllers/IdentityController.cs
+++ b/src/server/Modules/Identity/Modules.Identity/Controllers/IdentityController.cs
@@ -30,6 +30,13 @@ namespace FluentPOS.Modules.Identity.Controllers
             return Ok(await _identityService.ConfirmEmailAsync(userId, code));
         }
 
+        [HttpGet("/api/identity/confirm-phone-number")]
+        [AllowAnonymous]
+        public async Task<IActionResult> ConfirmSmsAsync([FromQuery] string userId, [FromQuery] string code)
+        {
+            return Ok(await _identityService.ConfirmSmsAsync(userId, code));
+        }
+
         [HttpPost("/api/identity/forgot-password")]
         [AllowAnonymous]
         public async Task<IActionResult> ForgotPasswordAsync(ForgotPasswordRequest request)

--- a/src/server/Modules/Identity/Modules.Identity/Controllers/IdentityController.cs
+++ b/src/server/Modules/Identity/Modules.Identity/Controllers/IdentityController.cs
@@ -32,9 +32,9 @@ namespace FluentPOS.Modules.Identity.Controllers
 
         [HttpGet("/api/identity/confirm-phone-number")]
         [AllowAnonymous]
-        public async Task<IActionResult> ConfirmSmsAsync([FromQuery] string userId, [FromQuery] string code)
+        public async Task<IActionResult> ConfirmPhoneNumberAsync([FromQuery] string userId, [FromQuery] string code)
         {
-            return Ok(await _identityService.ConfirmSmsAsync(userId, code));
+            return Ok(await _identityService.ConfirmPhoneNumberAsync(userId, code));
         }
 
         [HttpPost("/api/identity/forgot-password")]

--- a/src/server/Shared/Shared.Core/Interfaces/Services/ISmsService.cs
+++ b/src/server/Shared/Shared.Core/Interfaces/Services/ISmsService.cs
@@ -1,0 +1,10 @@
+﻿using System.Threading.Tasks;
+using FluentPOS.Shared.DTOs.Sms;
+
+namespace FluentPOS.Shared.Core.Interfaces.Services
+{
+    public interface ISmsService
+    {
+        Task SendAsync(SmsRequest request);
+    }
+}

--- a/src/server/Shared/Shared.Core/Settings/MailSettings.cs
+++ b/src/server/Shared/Shared.Core/Settings/MailSettings.cs
@@ -8,5 +8,6 @@
         public string UserName { get; set; }
         public string Password { get; set; }
         public string DisplayName { get; set; }
+        public bool EnableVerification { get; set; }
     }
 }

--- a/src/server/Shared/Shared.Core/Settings/SmsSettings.cs
+++ b/src/server/Shared/Shared.Core/Settings/SmsSettings.cs
@@ -1,0 +1,10 @@
+﻿namespace FluentPOS.Shared.Core.Settings
+{
+    public class SmsSettings
+    {
+        public string SmsAccountIdentification { get; set; }
+        public string SmsAccountPassword { get; set; }
+        public string SmsAccountFrom { get; set; }
+        public bool EnableVerification { get; set; }
+    }
+}

--- a/src/server/Shared/Shared.DTOs/Sms/SmsRequest.cs
+++ b/src/server/Shared/Shared.DTOs/Sms/SmsRequest.cs
@@ -1,0 +1,9 @@
+﻿namespace FluentPOS.Shared.DTOs.Sms
+{
+    public class SmsRequest
+    {
+        public string Number { get; set; }
+
+        public string Message { get; set; }
+    }
+}

--- a/src/server/Shared/Shared.Infrastructure/Extensions/ServiceCollectionExtensions.cs
+++ b/src/server/Shared/Shared.Infrastructure/Extensions/ServiceCollectionExtensions.cs
@@ -30,8 +30,10 @@ namespace FluentPOS.Shared.Infrastructure.Extensions
         {
             services.AddTransient<IUploadService, UploadService>();
             services.AddTransient<IMailService, SmtpMailService>();
+            services.AddTransient<ISmsService, TwilioSmsService>();
             services.AddScoped<IJobService, HangfireService>();
             services.Configure<MailSettings>(config.GetSection(nameof(MailSettings)));
+            services.Configure<SmsSettings>(config.GetSection(nameof(SmsSettings)));
             return services;
         }
 

--- a/src/server/Shared/Shared.Infrastructure/Services/TwilioSmsService.cs
+++ b/src/server/Shared/Shared.Infrastructure/Services/TwilioSmsService.cs
@@ -1,0 +1,46 @@
+﻿using System.Threading.Tasks;
+using FluentPOS.Shared.Core.Interfaces.Services;
+using FluentPOS.Shared.Core.Settings;
+using FluentPOS.Shared.DTOs.Sms;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Twilio;
+using Twilio.Rest.Api.V2010.Account;
+using Twilio.Types;
+
+namespace FluentPOS.Shared.Infrastructure.Services
+{
+    public class TwilioSmsService : ISmsService
+    {
+        private readonly SmsSettings _settings;
+        private readonly ILogger<TwilioSmsService> _logger;
+
+        public TwilioSmsService(IOptions<SmsSettings> settings, ILogger<TwilioSmsService> logger)
+        {
+            _settings = settings.Value;
+            _logger = logger;
+        }
+
+        public Task SendAsync(SmsRequest request)
+        {
+            try
+            {
+                var accountSid = _settings.SmsAccountIdentification;
+                var authToken = _settings.SmsAccountPassword;
+
+                TwilioClient.Init(accountSid, authToken);
+
+                return MessageResource.CreateAsync(
+                    to: new PhoneNumber(request.Number),
+                    from: new PhoneNumber(_settings.SmsAccountFrom),
+                    body: request.Message);
+            }
+            catch (System.Exception ex)
+            {
+                _logger.LogError(ex.Message, ex);
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/server/Shared/Shared.Infrastructure/Shared.Infrastructure.csproj
+++ b/src/server/Shared/Shared.Infrastructure/Shared.Infrastructure.csproj
@@ -31,5 +31,6 @@
     <PackageReference Include="MimeKit" Version="2.13.0" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.7" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.1.4" />
+    <PackageReference Include="Twilio" Version="5.62.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Add `TwilioSmsService` for sending verification code by SMS.

[More info](https://www.twilio.com/docs/messaging/services/tutorials/how-to-send-sms-messages-services-csharp).

P.S. Tested by trial Twilio account.